### PR TITLE
opsworks status should not crash on an empty query

### DIFF
--- a/lib/opsworks/cli/subcommands/status.rb
+++ b/lib/opsworks/cli/subcommands/status.rb
@@ -25,8 +25,8 @@ module OpsWorks
                 [stack.name, name, "(#{app.revision})", deployed_at]
               end
               # Sort output in descending date order
-              table.sort! { |x, y| y.last <=> x.last }
               table.compact!
+              table.sort! { |x, y| y.last <=> x.last }
               print_table table
             end
 


### PR DESCRIPTION
When supplying the name of an app that does not exist the status command now crashes. Moving the compact!  before the sort! fixes the problem.

On a side note I wish there was some spec coverage on the project :)
