### PR TITLE
Use a blank custom_json for stacks that lack the attr

### DIFF
--- a/lib/opsworks/stack.rb
+++ b/lib/opsworks/stack.rb
@@ -19,7 +19,7 @@ module OpsWorks
         new(
           id: hash[:stack_id],
           name: hash[:name],
-          custom_json: JSON.parse(hash[:custom_json])
+          custom_json: JSON.parse(hash.fetch(:custom_json, '{}'))
         )
       end
     end


### PR DESCRIPTION
We have a couple test stacks that don't set any custom json.  This caused opsworks-cli to fail with a stack trace while parsing our stacks.  This is a simple patch to supply an empty custom_json if the key is missing.

P.S. Excellent gem, thanks for sharing it!