### PR TITLE
Rename upgrade-chef to chef:configure and support more options

### DIFF
--- a/lib/opsworks/cli/agent.rb
+++ b/lib/opsworks/cli/agent.rb
@@ -5,7 +5,7 @@ require_relative 'helpers/credentials'
 require_relative 'helpers/options'
 
 require_relative 'subcommands/update'
-require_relative 'subcommands/upgrade_chef'
+require_relative 'subcommands/chef'
 require_relative 'subcommands/recipes'
 require_relative 'subcommands/apps'
 require_relative 'subcommands/iam'
@@ -20,7 +20,7 @@ module OpsWorks
       include Helpers::Options
 
       include Subcommands::Update
-      include Subcommands::UpgradeChef
+      include Subcommands::Chef
       include Subcommands::Recipes
       include Subcommands::Apps
       include Subcommands::IAM

--- a/lib/opsworks/cli/subcommands/chef.rb
+++ b/lib/opsworks/cli/subcommands/chef.rb
@@ -4,22 +4,27 @@ require 'opsworks/stack'
 module OpsWorks
   module CLI
     module Subcommands
-      module UpgradeChef
+      module Chef
         # rubocop:disable MethodLength
         # rubocop:disable CyclomaticComplexity
         def self.included(thor)
           thor.class_eval do
-            desc 'upgrade-chef [--stack STACK]', 'Upgrade Chef version'
+            desc 'chef:configure [--stack STACK]', 'Configure Chef/Berkshelf'
             option :stack, type: :array
-            option :version
+            option :version, default: OpsWorks::Stack.latest_chef_version
             option :manage_berkshelf, type: :boolean, default: false
-            def upgrade_chef
+            option :berkshelf_version, default: '3.2.0'
+            option :cookbook_git_url
+            option :cookbook_branch
+            option :cookbook_s3_url
+            option :cookbook_username
+            option :cookbook_password
+            define_method 'chef:configure' do
               fetch_credentials unless env_credentials?
               stacks = parse_stacks(options.merge(active: true))
-              version = OpsWorks::Stack.latest_chef_version
               stacks.each do |stack|
-                say "Upgrading #{stack.name} to #{version}..."
-                stack.upgrade_chef(version, options)
+                say "Configuring Chef #{options[:version]} on #{stack.name}..."
+                stack.update_chef(options)
               end
             end
           end

--- a/lib/opsworks/stack.rb
+++ b/lib/opsworks/stack.rb
@@ -60,12 +60,30 @@ module OpsWorks
       @layers ||= initialize_layers
     end
 
-    def upgrade_chef(version, options = {})
-      self.class.client.update_stack(
+    def update_chef(options)
+      params = {
         stack_id: id,
-        configuration_manager: { name: 'Chef', version: version },
-        chef_configuration: { manage_berkshelf: options[:manage_berkshelf] }
-      )
+        configuration_manager: { name: 'Chef', version: options[:version] },
+        chef_configuration: {
+          manage_berkshelf: options[:manage_berkshelf],
+          berkshelf_version: options[:berkshelf_version]
+        }
+      }
+      if options[:cookbook_git_url]
+        params[:custom_cookbooks_source] = {
+          type: 'git',
+          url: options[:cookbook_git_url],
+          revision: options[:cookbook_branch] || 'master'
+        }
+      elsif options[:cookbook_s3_url]
+        params[:custom_cookbooks_source] = {
+          type: 's3',
+          url: options[:cookbook_s3_url],
+          username: options[:cookbook_username],
+          password: options[:cookbook_password]
+        }
+      end
+      self.class.client.update_stack(params)
     end
 
     def update_custom_cookbooks


### PR DESCRIPTION
Now, you can configure the cookbook source (Git or S3), along with the branch (for Git sources) or username/password (for S3 sources).

Tested via the following script, to switch to Git-sourced, Berkshelf-managed cookbooks:

```
opsworks chef:configure --version 11.10 --manage-berkshelf --berkshelf-version 3.2.0 --cookbook-git-url https://github.com/aptible/aptible-cookbook.git --cookbook-branch release
```