### PR TITLE
Fix --stack parameter

### DIFF
--- a/lib/opsworks/cli/helpers/options.rb
+++ b/lib/opsworks/cli/helpers/options.rb
@@ -6,7 +6,7 @@ module OpsWorks
       module Options
         def parse_stacks(options = {})
           if options[:stack]
-            OpsWorks::Stack.all.select! do |stack|
+            OpsWorks::Stack.all.select do |stack|
               options[:stack].include?(stack.name)
             end
           else


### PR DESCRIPTION
The Options helper module is currently doing a `select!` which is modifying in-place and returning nil.  This PR replaces with `select` to fix the --stack input parameter. 