### PR TITLE
Add migration support to apps:deploy

### DIFF
--- a/lib/opsworks/cli/subcommands/apps.rb
+++ b/lib/opsworks/cli/subcommands/apps.rb
@@ -12,13 +12,14 @@ module OpsWorks
             desc 'apps:deploy APP [--stack STACK]', 'Deploy an OpsWorks app'
             option :stack, type: :array
             option :timeout, type: :numeric, default: 300
+            option :migrate, type: :boolean, default: false
             define_method 'apps:deploy' do |name|
               fetch_credentials unless env_credentials?
               stacks = parse_stacks(options.merge(active: true))
               deployments = stacks.map do |stack|
                 next unless (app = stack.find_app_by_name(name))
                 say "Deploying to #{stack.name}..."
-                stack.deploy_app(app)
+                stack.deploy_app(app, 'migrate' => [options[:migrate].to_s])
               end
               deployments.compact!
               OpsWorks::Deployment.wait(deployments, options[:timeout])

--- a/lib/opsworks/stack.rb
+++ b/lib/opsworks/stack.rb
@@ -99,9 +99,10 @@ module OpsWorks
       )
     end
 
-    def deploy_app(app, args={})
+    def deploy_app(app, args = {})
       fail 'App not found' unless app && app.id
-      create_deployment(app_id: app.id,
+      create_deployment(
+        app_id: app.id,
         command: {
           name: 'deploy',
           args: args

--- a/lib/opsworks/stack.rb
+++ b/lib/opsworks/stack.rb
@@ -99,9 +99,14 @@ module OpsWorks
       )
     end
 
-    def deploy_app(app)
+    def deploy_app(app, args={})
       fail 'App not found' unless app && app.id
-      create_deployment(app_id: app.id, command: { name: 'deploy' })
+      create_deployment(app_id: app.id,
+        command: {
+          name: 'deploy',
+          args: args
+        }
+      )
     end
 
     def active?

--- a/spec/opsworks/cli/subcommands/apps_spec.rb
+++ b/spec/opsworks/cli/subcommands/apps_spec.rb
@@ -20,20 +20,24 @@ describe OpsWorks::CLI::Agent do
       end
 
       it 'should update custom cookbooks on all stacks' do
-        expect(stacks[0]).to receive(:deploy_app).with(app, anything) { success }
-        expect(stacks[1]).to receive(:deploy_app).with(app, anything) { success }
+        expect(stacks[0]).to receive(:deploy_app)
+          .with(app, anything) { success }
+        expect(stacks[1]).to receive(:deploy_app)
+          .with(app, anything) { success }
         subject.send('apps:deploy', app_name)
       end
 
       it 'should not fail if some stacks are inactive' do
         allow(OpsWorks::Stack).to receive(:active) { [stacks[0]] }
-        expect(stacks[0]).to receive(:deploy_app).with(app, anything) { success }
+        expect(stacks[0]).to receive(:deploy_app)
+          .with(app, anything) { success }
         expect(stacks[1]).not_to receive(:deploy_app)
         subject.send('apps:deploy', app_name)
       end
 
       it 'should optionally run on a subset of stacks' do
-        expect(stacks[0]).to receive(:deploy_app).with(app, anything) { success }
+        expect(stacks[0]).to receive(:deploy_app)
+          .with(app, anything) { success }
         expect(stacks[1]).not_to receive(:deploy_app)
 
         allow(subject).to receive(:options) { { stack: [stacks[0].name] } }
@@ -41,8 +45,10 @@ describe OpsWorks::CLI::Agent do
       end
 
       it 'should optionally run migrations' do
-        expect(stacks[0]).to receive(:deploy_app).with(app, {'migrate' => ['true']}) { success }
-        expect(stacks[1]).to receive(:deploy_app).with(app, {'migrate' => ['true']}) { success }
+        expect(stacks[0]).to receive(:deploy_app)
+          .with(app, 'migrate' => ['true']) { success }
+        expect(stacks[1]).to receive(:deploy_app)
+          .with(app, 'migrate' => ['true']) { success }
 
         allow(subject).to receive(:options) { { migrate: true } }
         subject.send('apps:deploy', app_name)
@@ -50,12 +56,14 @@ describe OpsWorks::CLI::Agent do
 
       it 'should not fail if a stack does not have the app' do
         allow(stacks[0]).to receive(:apps) { [] }
-        expect(stacks[1]).to receive(:deploy_app).with(app, anything) { success }
+        expect(stacks[1]).to receive(:deploy_app)
+          .with(app, anything) { success }
         expect { subject.send('apps:deploy', app_name) }.not_to raise_error
       end
 
       it 'should fail if any update fails' do
-        expect(stacks[0]).to receive(:deploy_app).with(app, anything) { failure }
+        expect(stacks[0]).to receive(:deploy_app)
+          .with(app, anything) { failure }
 
         allow(subject).to receive(:options) { { stack: [stacks[0].name] } }
         expect { subject.send('apps:deploy', app_name) }.to raise_error

--- a/spec/opsworks/cli/subcommands/apps_spec.rb
+++ b/spec/opsworks/cli/subcommands/apps_spec.rb
@@ -20,34 +20,42 @@ describe OpsWorks::CLI::Agent do
       end
 
       it 'should update custom cookbooks on all stacks' do
-        expect(stacks[0]).to receive(:deploy_app).with(app) { success }
-        expect(stacks[1]).to receive(:deploy_app).with(app) { success }
+        expect(stacks[0]).to receive(:deploy_app).with(app, anything) { success }
+        expect(stacks[1]).to receive(:deploy_app).with(app, anything) { success }
         subject.send('apps:deploy', app_name)
       end
 
       it 'should not fail if some stacks are inactive' do
         allow(OpsWorks::Stack).to receive(:active) { [stacks[0]] }
-        expect(stacks[0]).to receive(:deploy_app).with(app) { success }
+        expect(stacks[0]).to receive(:deploy_app).with(app, anything) { success }
         expect(stacks[1]).not_to receive(:deploy_app)
         subject.send('apps:deploy', app_name)
       end
 
       it 'should optionally run on a subset of stacks' do
-        expect(stacks[0]).to receive(:deploy_app).with(app) { success }
+        expect(stacks[0]).to receive(:deploy_app).with(app, anything) { success }
         expect(stacks[1]).not_to receive(:deploy_app)
 
         allow(subject).to receive(:options) { { stack: [stacks[0].name] } }
         subject.send('apps:deploy', app_name)
       end
 
+      it 'should optionally run migrations' do
+        expect(stacks[0]).to receive(:deploy_app).with(app, {'migrate' => ['true']}) { success }
+        expect(stacks[1]).to receive(:deploy_app).with(app, {'migrate' => ['true']}) { success }
+
+        allow(subject).to receive(:options) { { migrate: true } }
+        subject.send('apps:deploy', app_name)
+      end
+
       it 'should not fail if a stack does not have the app' do
         allow(stacks[0]).to receive(:apps) { [] }
-        expect(stacks[1]).to receive(:deploy_app).with(app) { success }
+        expect(stacks[1]).to receive(:deploy_app).with(app, anything) { success }
         expect { subject.send('apps:deploy', app_name) }.not_to raise_error
       end
 
       it 'should fail if any update fails' do
-        expect(stacks[0]).to receive(:deploy_app).with(app) { failure }
+        expect(stacks[0]).to receive(:deploy_app).with(app, anything) { failure }
 
         allow(subject).to receive(:options) { { stack: [stacks[0].name] } }
         expect { subject.send('apps:deploy', app_name) }.to raise_error


### PR DESCRIPTION
Hi, I wanted to shoot this PR your way for adding migration support to the `apps:deploy` command.  I added a basic test for the new param and modified the existing tests to match the change in signature for Opsworks::Stack#deploy_app.

I've also tested this against one of our live AWS opsworks stacks and verified it a) migrates the application when `--migrate` is passed and b) doesn't migrate the application when it is omitted.