### PR TITLE
Run custom JSON through a pretty-printer before setting.

### DIFF
--- a/lib/opsworks/stack.rb
+++ b/lib/opsworks/stack.rb
@@ -123,7 +123,7 @@ module OpsWorks
 
       self.class.client.update_stack(
         stack_id: id,
-        custom_json: custom_json.to_json
+        custom_json: JSON.pretty_generate(custom_json)
       )
     end
 


### PR DESCRIPTION
Tested on my own stack and verified that the generated JSON looks at least 50% prettier than a text blob.