### PR TITLE
Add apps:revision:update command

### DIFF
--- a/lib/opsworks/app.rb
+++ b/lib/opsworks/app.rb
@@ -20,6 +20,15 @@ module OpsWorks
       deployments.find(&:success?)
     end
 
+    def update_revision(revision)
+      self.class.client.update_app(
+        app_id: id,
+        app_source: { revision: revision }
+      )
+
+      self.revision = revision
+    end
+
     private
 
     def initialize_deployments

--- a/lib/opsworks/cli/subcommands/apps.rb
+++ b/lib/opsworks/cli/subcommands/apps.rb
@@ -75,6 +75,19 @@ module OpsWorks
               end
             end
 
+            desc 'apps:revision:update APP REVISION [--stack STACK]',
+                 'Set the revision for an app'
+            option :stack, type: :array
+            define_method 'apps:revision:update' do |app_name, revision|
+              fetch_credentials unless env_credentials?
+              stacks = parse_stacks(options.merge(active: true))
+              stacks.each do |stack|
+                next unless (app = stack.find_app_by_name(app_name))
+                say "Updating #{stack.name} (from: #{app.revision})..."
+                app.update_revision(revision)
+              end
+            end
+
             private
 
             def formatted_time(timestamp)


### PR DESCRIPTION
This sets the revision on an app (not touching any other deployment
parameters). In practice, this will be useful to update the branch for
our existing v1 deployments.

cc @fancyremarker 