### PR TITLE
 Add :layer option to recipes:run

### DIFF
--- a/lib/opsworks/cli/subcommands/recipes.rb
+++ b/lib/opsworks/cli/subcommands/recipes.rb
@@ -7,11 +7,12 @@ module OpsWorks
             desc 'recipes:run RECIPE [--stack STACK]', 'Execute a Chef recipe'
             option :stack, type: :array
             option :timeout, type: :numeric, default: 300
+            option :layer, type: :string
             define_method 'recipes:run' do |recipe|
               stacks = parse_stacks(options.merge(active: true))
               deployments = stacks.map do |stack|
                 say "Executing recipe on #{stack.name}..."
-                stack.execute_recipe(recipe)
+                stack.execute_recipe(recipe, layer: options[:layer])
               end
               OpsWorks::Deployment.wait(deployments, options[:timeout])
               unless deployments.all?(&:success?)

--- a/lib/opsworks/stack.rb
+++ b/lib/opsworks/stack.rb
@@ -103,13 +103,17 @@ module OpsWorks
       create_deployment(command: { name: 'update_custom_cookbooks' })
     end
 
-    def execute_recipe(recipe)
-      create_deployment(
+    def execute_recipe(recipe, layer: nil)
+      deploy_args = {
         command: {
           name: 'execute_recipes',
           args: { 'recipes' => [recipe] }
         }
-      )
+      }
+
+      deploy_args[:layer_ids] = [layer_id_from_name(layer)] if layer
+
+      create_deployment(**deploy_args)
     end
 
     def deploy_app(app, layer: nil, args: {})
@@ -123,11 +127,7 @@ module OpsWorks
         }
       }
 
-      if layer
-        layer = layers.find { |l| l.shortname == layer }
-        raise "Layer #{layer} not found" unless layer
-        deploy_args[:layer_ids] = [layer.id]
-      end
+      deploy_args[:layer_ids] = [layer_id_from_name(layer)] if layer
 
       create_deployment(**deploy_args)
     end
@@ -192,6 +192,12 @@ module OpsWorks
       hash
     end
     # rubocop:enable Eval
+
+    def layer_id_from_name(shortname)
+      layer = layers.find { |l| l.shortname == shortname }
+      raise "Layer #{layer} not found" unless layer
+      layer.id
+    end
 
     def initialize_apps
       return [] unless id

--- a/opsworks-cli.gemspec
+++ b/opsworks-cli.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'thor'
-  spec.add_dependency 'aws-sdk', '~> 2.9.6'
+  spec.add_dependency 'aws-sdk', '~> 2.11.192'
   spec.add_dependency 'jsonpath'
   spec.add_dependency 'activesupport'
 

--- a/spec/opsworks/cli/subcommands/recipes_spec.rb
+++ b/spec/opsworks/cli/subcommands/recipes_spec.rb
@@ -13,23 +13,33 @@ describe OpsWorks::CLI::Agent do
     describe 'recipes:run' do
       let(:success) { Fabricate(:deployment, status: 'successful') }
       let(:failure) { Fabricate(:deployment, status: 'failed') }
+      let(:args) { [recipe, { layer: nil }] }
 
       it 'should update custom cookbooks on all stacks' do
-        expect(stacks[0]).to receive(:execute_recipe).with(recipe) { success }
-        expect(stacks[1]).to receive(:execute_recipe).with(recipe) { success }
+        expect(stacks[0]).to receive(:execute_recipe).with(*args) { success }
+        expect(stacks[1]).to receive(:execute_recipe).with(*args) { success }
         subject.send('recipes:run', recipe)
       end
 
       it 'should optionally run on a subset of stacks' do
-        expect(stacks[0]).to receive(:execute_recipe).with(recipe) { success }
+        expect(stacks[0]).to receive(:execute_recipe).with(*args) { success }
         expect(stacks[1]).not_to receive(:execute_recipe)
 
         allow(subject).to receive(:options) { { stack: [stacks[0].name] } }
         subject.send('recipes:run', recipe)
       end
 
+      it 'should optionally run on a single layer' do
+        args = [recipe, { layer: 'git' }]
+        expect(stacks[0]).to receive(:execute_recipe).with(*args) { success }
+        expect(stacks[1]).to receive(:execute_recipe).with(*args) { success }
+
+        allow(subject).to receive(:options) { { layer: 'git' } }
+        subject.send('recipes:run', recipe)
+      end
+
       it 'should fail if any update fails' do
-        expect(stacks[0]).to receive(:execute_recipe).with(recipe) { failure }
+        expect(stacks[0]).to receive(:execute_recipe).with(*args) { failure }
 
         allow(subject).to receive(:options) { { stack: [stacks[0].name] } }
         expect { subject.send('recipes:run', recipe) }.to raise_error


### PR DESCRIPTION
The goal here is to be able to specify `:layer` as an argument to `opsworks recipes:run`. For example:

```
opsworks recipes:run aptible::dns --layer nat
```

...will run the `aptible::dns` recipe only on the NAT layer. cc: @almathew 