### PR TITLE
Capture and report service errors for instances in setup_failed state

### DIFF
--- a/lib/opsworks/cli/subcommands/instances.rb
+++ b/lib/opsworks/cli/subcommands/instances.rb
@@ -11,11 +11,16 @@ module OpsWorks
               stacks = parse_stacks(options)
               stacks.each do |stack|
                 stack.instances.each do |instance|
-                  say [
+                  arr = [
                     stack.name,
                     instance.hostname,
                     instance.status
-                  ].join("\t")
+                  ]
+                  # TODO: Why does a EOL tab break say?
+                  if (errors = instance.service_errors).any?
+                    arr << errors.join(', ')
+                  end
+                  say arr.join("\t")
                 end
               end
             end

--- a/spec/fabricators/opsworks/instance_fabricator.rb
+++ b/spec/fabricators/opsworks/instance_fabricator.rb
@@ -3,4 +3,5 @@ Fabricator(:instance, from: OpsWorks::Instance) do
   id { SecureRandom.uuid }
   hostname { Fabricate.sequence { |i| "test-instance#{i}" } }
   status { 'online' }
+  service_errors { [] }
 end


### PR DESCRIPTION
This was particularly helpful in debugging instance start failures in ca-central-1.
